### PR TITLE
Fix docs site build

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -16,5 +16,5 @@ jobs:
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:
-          REQUIREMENTS: dev-requirements.txt
+          REQUIREMENTS: docs/requirements.txt
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs
+mkdocs-material

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs
 mkdocs-material
+mkdocstrings


### PR DESCRIPTION
`mhausenblas/mkdocs-deploy-gh-pages` needs a requirements file, else it tries to install the repo-level requirements, which typically are not needed for the docs site, see: https://github.com/mhausenblas/mkdocs-deploy-gh-pages/issues/53

This PR introduces a requirements file specific to the docs site, fixing an issue with trying to install the dev-requirements.txt.

The underlying issue was with trying to install black into the Docker image used by this GitHub Action (squidfunk/mkdocs-material:7.1.8), see: https://github.com/mhausenblas/mkdocs-deploy-gh-pages/blob/master/Dockerfile

Recent versions of black depend on regex, which has a history of trouble with Linux wheel availability and support

* https://github.com/psf/black/issues/1207
* https://bitbucket.org/mrabarnett/mrab-regex/issues/343/wheel-for-linux
* https://bitbucket.org/mrabarnett/mrab-regex/issues/349/no-module-named-regex_regex-regex-is-not-a

The Docker image does not have gcc available; rather than installing a build chain to build regex to enable the install of black, which isn't even used by the docs site, the simpler fix was to create a docs/requirements.txt and point the GitHub Action at it instead.

Similar report on the Action repo: https://github.com/mhausenblas/mkdocs-deploy-gh-pages/issues/105
